### PR TITLE
alter zk connection string to 127.0.0.1 the mosn proxied address if environment variable indicate it's in mesh is set

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/MetadataReportConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/MetadataReportConfig.java
@@ -84,6 +84,9 @@ public class MetadataReportConfig extends AbstractConfig {
      */
     private String registry;
 
+    private static final String DMOSN_ENABLE = "DMOSN_ENABLE";
+    private static final String MOSN_ZK_METADATA_REGISTRY = "MOSN_ZK_METADATA_REGISTRY";
+
     public MetadataReportConfig() {
     }
 
@@ -107,6 +110,20 @@ public class MetadataReportConfig extends AbstractConfig {
         map.putAll(convert(map, null));
         // put the protocol of URL as the "metadata"
         map.put("metadata", url.getProtocol());
+        String dmosnEnable = StringUtils.isEmpty(System.getenv(DMOSN_ENABLE)) ? System.getProperty(DMOSN_ENABLE) : System.getenv(DMOSN_ENABLE);
+        if ("true".equals(dmosnEnable)) {
+            String mzmRegistry = StringUtils.isEmpty(System.getenv(MOSN_ZK_METADATA_REGISTRY)) ? System.getProperty(MOSN_ZK_METADATA_REGISTRY) : System.getenv(MOSN_ZK_METADATA_REGISTRY);
+            if (map.containsKey("clusters")) {
+                map.put("clusters", StringUtils.isEmpty(mzmRegistry) ? "127.0.0.1:2181|127.0.0.1:2181" : mzmRegistry);
+            }
+            if (StringUtils.isNotEmpty(mzmRegistry)) {
+                String[] string = mzmRegistry.split(":");
+                return new URL("metadata", url.getUsername(), url.getPassword(), string[0],
+                       Integer.parseInt(string[1]), url.getPath(), map);
+            }
+            return new URL("metadata", url.getUsername(), url.getPassword(), "127.0.0.1",
+                    2181, url.getPath(), map);
+        }
         return new URL("metadata", url.getUsername(), url.getPassword(), url.getHost(),
                 url.getPort(), url.getPath(), map);
 


### PR DESCRIPTION
## What is the purpose of the change

Add logic to check the `DMOSN_ENABLE=true` environment variable is set. If so, it means the package was deployed in mesh, so alter the zk connection string to 127.0.0.1 which the one mosn proxied.

## Brief changelog

XXXXX

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
